### PR TITLE
Remove implicit append to document.body

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 module.exports = BaseElement
 
-var document = require('global/document')
 var serialize = require('min-document/serialize')
 var h = require('virtual-dom/h')
 var diff = require('virtual-dom/diff')
@@ -11,7 +10,7 @@ function BaseElement (el) {
   if (!(this instanceof BaseElement)) return new BaseElement(el)
   this.vtree = null
   this.element = null
-  this.__appendTo__ = el == null ? document.body : el
+  this.__appendTo__ = el
   this.__events__ = Object.create(null)
   this.__BaseElementSig__ = 'be-' + Date.now()
   this.__onload__ = new Onload(this.send.bind(this))
@@ -40,7 +39,7 @@ BaseElement.prototype.render = function (vtree) {
   if (!this.vtree) {
     this.vtree = vtree
     this.element = createElement(this.vtree)
-    if (this.__appendTo__ !== false) {
+    if (this.__appendTo__) {
       this.__appendTo__.appendChild(this.element)
     }
   } else {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "zuul": "^3.0.0"
   },
   "dependencies": {
-    "global": "^4.3.0",
     "min-document": "^2.14.1",
     "virtual-dom": "^2.0.1"
   }

--- a/test/index.js
+++ b/test/index.js
@@ -55,7 +55,7 @@ test('load event fired', function (t) {
 test('unload event fired', function (t) {
   t.plan(1)
   setUp(function (fixture) {
-    var button = new Button(false)
+    var button = new Button()
     button.on('unload', function (node) {
       t.equal(node.innerHTML, 'Test')
       tearDown(fixture, t.end)

--- a/test/server.js
+++ b/test/server.js
@@ -4,7 +4,7 @@ var Nested = require('./fixtures/nested.js')
 
 test('toString on server side', function (t) {
   t.plan(1)
-  var nested = new Nested(false)
+  var nested = new Nested()
   t.equal(nested.toString('test'), '<div class="top"><ul class="middle"><li class="bottom">test</li></ul></div>')
   t.end()
 })


### PR DESCRIPTION
Since this is a breaking change, feel free to leave this open and merge when convenient

Side effects:
- Update tests, replace `new El(false)` with `new El()`
- Remove "global" dep since there's no `document` usage

Closes #9
