### PR TITLE
Allow PRs to be tested on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_install:
 - npm install npm -g
 before_script:
 - npm install
-script: npm run ci
+script: 'if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then npm run ci; else npm run test-pr; fi'
 addons:
   sauce_connect: true
 env:

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "standard && node test/server.js && zuul --local 9966 -- test/index.js",
     "ci": "standard && node test/server.js && zuul -- test/index.js",
+    "test-pr": "standard && node test/server.js && npm i -D electron-prebuilt && zuul --electron -- test/index.js",
     "start": "budo examples/standalone.js",
     "build": "browserify index.js --standalone BaseElement -o dist/base-element.js",
     "prepublish": "npm run build"


### PR DESCRIPTION
Travis encrypted env vars are excluded from PRs so instead we install electron and test locally
