### PR TITLE
Ignore non fn callback to addEventListener

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,12 +61,13 @@ BaseElement.prototype.send = function (name) {
   var args = Array.prototype.slice.call(arguments, 1)
   for (var i = 0; i < found.length; i++) {
     var fn = found[i]
-    if (typeof fn === 'function') fn.apply(this, args)
+    fn.apply(this, args)
   }
   return this
 }
 
 BaseElement.prototype.addEventListener = function (name, cb) {
+  if (typeof cb !== 'function') return
   if (!Array.isArray(this.__events__[name])) this.__events__[name] = []
   this.__events__[name].push(cb)
 }


### PR DESCRIPTION
This is in line with browser behavior. When `el.addEventListener.bind(el, 'theEvent')` is called with a non-function, the call is a noop. This eliminates a need to type check the listener every time `send` is called.
